### PR TITLE
An ability to use a custom socket instead of the :gen_tcp/:inet

### DIFF
--- a/examples/pool_example/config/config.exs
+++ b/examples/pool_example/config/config.exs
@@ -3,9 +3,9 @@
 use Mix.Config
 
 config :pool_example, PoolExample,
-  host: "192.168.252.128",
+  host: "127.0.0.1",
   port: 7687,
-  auth: {},
+  auth: {"neo4j", "password"},
   pool: DBConnection.Poolboy,
   name: :boltex_pool
 

--- a/examples/pool_example/lib/pool_example.ex
+++ b/examples/pool_example/lib/pool_example.ex
@@ -5,7 +5,7 @@ defmodule PoolExample do
     import Supervisor.Spec, warn: false
 
     children = [
-      supervisor(DBConnection, [Boltex.Connection, boltex_pool_opts()]),
+      supervisor(DBConnection, [BoltexDBConnection.Connection, boltex_pool_opts()]),
     ]
 
     opts = [strategy: :one_for_one, name: PoolExample.Supervisor]
@@ -15,7 +15,7 @@ defmodule PoolExample do
   def query(statement, params \\ %{}) do
     name  = boltex_pool_opts[:name]
     pool  = boltex_pool_opts[:pool]
-    query = %Boltex.Query{statement: statement}
+    query = %BoltexDBConnection.Query{statement: statement}
     opts  = [pool: pool]
 
     DBConnection.run name, &DBConnection.execute(&1, query, params, []), opts

--- a/lib/boltex_db_connection/socket.ex
+++ b/lib/boltex_db_connection/socket.ex
@@ -1,0 +1,31 @@
+defmodule BoltexDBConnection.Socket do
+  @moduledoc """
+  A default socket interface used to communicate to a Neo4j instance.
+
+  Any other socket implementing the same interface can be used
+  in place of this one. Actually, this module doesn't
+  implement the interface on its own, it delegates calls to
+  the gen_tcp (http://erlang.org/doc/man/gen_tcp.html)
+  and inet (http://erlang.org/doc/man/inet.html) modules. Any of these
+  modules doesn't fully implement the require interface,
+  hence, both of them must be used.
+  """
+
+  @doc "Delegates to :gen_tcp.connect/4"
+  defdelegate connect(host, port, opts, timeout), to: :gen_tcp
+
+  @doc "Delegates to :inet.setopts/2"
+  defdelegate setopts(sock, opts), to: :inet
+
+  @doc "Delegates to :gen_tcp.send/2"
+  defdelegate send(sock, package), to: :gen_tcp
+
+  @doc "Delegates to :gen_tcp.recv/3"
+  defdelegate recv(sock, length, timeout), to: :gen_tcp
+
+  @doc "Delegates to :gen_tcp.recv/2"
+  defdelegate recv(sock, length), to: :gen_tcp
+
+  @doc "Delegates to :inet.close/1"
+  defdelegate close(sock), to: :inet
+end

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule BoltexDbConnection.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :db_connection]]
   end
 
   # Dependencies can be Hex packages:
@@ -29,7 +29,7 @@ defmodule BoltexDbConnection.Mixfile do
   defp deps do
     [
       {:db_connection, "~> 1.1"},
-      {:boltex, path: "../boltex"}
+      {:boltex, "~> 0.3.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"boltex": {:hex, :boltex, "0.0.2", "5de7b36563a560bab7619468f846868fb461c476bdd13be02c143fbcc73e9a6e", [:hex], []},
+%{"boltex": {:hex, :boltex, "0.3.0", "9d08a310cb0e3c97938ead88bbfc3f3be8fad9a47036b8117ce76ac32a4045d2", [:hex], []},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "db_connection": {:hex, :db_connection, "1.1.0", "b2b88db6d7d12f99997b584d09fad98e560b817a20dab6a526830e339f54cdb3", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]}}

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -13,13 +13,13 @@ defmodule Boltex.ConnectionTest do
 
   @tag :integration
   test "executes a query successfully" do
-    assert {:ok, pid} = DBConnection.start_link Connection, [host: "192.168.252.128", port: 7688, auth: {"neo4j", "password"}]
+    assert {:ok, pid} = DBConnection.start_link Connection, [host: "127.0.0.1", port: 7688, auth: {"neo4j", "password"}]
     query = %Query{statement: "MATCH (n) RETURN n"}
     assert {:ok, [{:success, _} | _]} = DBConnection.execute pid, query, %{}, []
   end
 
   test "handles failures gracefully" do
-    assert {:ok, pid} = DBConnection.start_link Connection, [host: "192.168.252.128", port: 7688, auth: {"neo4j", "wrong!"}]
+    assert {:ok, pid} = DBConnection.start_link Connection, [host: "127.0.0.1", port: 7688, auth: {"neo4j", "wrong!"}]
     query = %Query{statement: "MATCH (n) RETURN n"}
 
     log = capture_log fn ->


### PR DESCRIPTION
Users of this library might need to use the :ssl (http://erlang.org/doc/man/ssl.html) lib or any other lib implementing a similar interface (for instance, https://github.com/kzemek/etls).

This PR provides a default socket module which wraps the :gen_tcp and :inet modules in order to
provide the required interface to communicate to a Neo4j instance.

Now, the lib can be configured to use another socket interface instead of the default one. 

Example:

```elixir
config = [
  host: "localhost",
  port: 7687,
  socket: :ssl,
  pool: DBConnection.Poolboy
]

DBConnection.child_spec(BoltexDBConnection.Connection, config)
```

Besides that, I changed the default host from `192.168.252.128` to `127.0.0.1` which is more common for developers :wink: 